### PR TITLE
Add block number created to join table schema

### DIFF
--- a/packages/layer2-token-gateway/schema.graphql
+++ b/packages/layer2-token-gateway/schema.graphql
@@ -17,6 +17,8 @@ type Token @entity {
 type TokenGatewayJoinTable @entity {
   "Set to concat `gateway.id` and `token.id`"
   id: ID!
+  "block in which the token-gateway were associated"
+  blockNum: BigInt!
   gateway: Gateway!
   token: Token!
   withdrawals: [Withdrawal!] @derivedFrom(field: "exitInfo")

--- a/packages/layer2-token-gateway/tests/weth/weth.test.ts
+++ b/packages/layer2-token-gateway/tests/weth/weth.test.ts
@@ -1,12 +1,9 @@
-import { addressToId, getJoinId, handleGatewaySet, handleDeposit } from "../../src/mapping";
-
+import { addressToId, getJoinId, handleGatewaySet, handleDeposit, DISABLED_GATEWAY_ADDR } from "../../src/mapping";
 import { Address, BigInt, Bytes, ethereum, store, log } from "@graphprotocol/graph-ts";
 import { newMockEvent, test, assert, createMockedFunction } from "matchstick-as";
 import { GatewaySet as GatewaySetEvent } from "../../generated/L2GatewayRouter/L2GatewayRouter";
 import { DepositFinalized as DepositFinalizedEvent } from "../../generated/templates/L2ArbitrumGateway/L2ArbitrumGateway";
 import { Gateway, Token, TokenGatewayJoinTable } from "../../generated/schema";
-
-const DISABLED_GATEWAY_ADDR = Address.fromString("0x0000000000000000000000000000000000000001");
 
 const createGatewaySet = (token: Address, gateway: Address): GatewaySetEvent => {
     let mockEvent = newMockEvent();


### PR DESCRIPTION
The gateway join table includes past gateways that were previously registered in the router.

For example, token X was previously registered to gateway A then got registered with gateway B.

The subgraph now tracks when the join table entry was created so that you can query for the latest Token/Gateway pair as follows:
```graphql
{
  tokens(
    first: 5
    where: { id:"0xc778417e063141139fce010982780140aa0cd5ab" }
  ) {
    l1TokenAddr: id
    joinTableEntry: gateway(
      first: 1
      orderBy: blockNum
      orderDirection: desc
    ) {
      id
      blockNum
      token {
        tokenAddr: id
      }
      gateway {
        gatewayAddr: id
      }
    }
  }
}
```

The new schema has been deployed to the testnet [rinekby subgraph](https://thegraph.com/hosted-service/subgraph/fredlacs/layer2-token-gateway-rinkeby)