### PR TITLE
Add pre processor with moustache and rollup node tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 build
+subgraph.preprocessed.yaml
 subgraph.yaml
 .bin
 generated

--- a/packages/arb-bridge-eth/abis/IRollupCore.json
+++ b/packages/arb-bridge-eth/abis/IRollupCore.json
@@ -1,0 +1,533 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "nodeNum",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "afterSendAcc",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "afterSendCount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "afterLogAcc",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "afterLogCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "NodeConfirmed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "nodeNum",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "parentNodeHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "nodeHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "executionHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "inboxMaxCount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "afterInboxBatchEndCount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "afterInboxBatchAcc",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[3][2]",
+        "name": "assertionBytes32Fields",
+        "type": "bytes32[3][2]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[4][2]",
+        "name": "assertionIntFields",
+        "type": "uint256[4][2]"
+      }
+    ],
+    "name": "NodeCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "nodeNum",
+        "type": "uint256"
+      }
+    ],
+    "name": "NodeRejected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "challengeContract",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "asserter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "challenger",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "challengedNode",
+        "type": "uint256"
+      }
+    ],
+    "name": "RollupChallengeStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "machineHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RollupCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "initialBalance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "finalBalance",
+        "type": "uint256"
+      }
+    ],
+    "name": "UserStakeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "initialBalance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "finalBalance",
+        "type": "uint256"
+      }
+    ],
+    "name": "UserWithdrawableFundsUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "stakerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "_stakerMap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "staker",
+        "type": "address"
+      }
+    ],
+    "name": "amountStaked",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "staker",
+        "type": "address"
+      }
+    ],
+    "name": "currentChallenge",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "firstUnresolvedNode",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nodeNum",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNode",
+    "outputs": [
+      {
+        "internalType": "contract INode",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNodeHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "stakerNum",
+        "type": "uint256"
+      }
+    ],
+    "name": "getStakerAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "staker",
+        "type": "address"
+      }
+    ],
+    "name": "isStaked",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "staker",
+        "type": "address"
+      }
+    ],
+    "name": "isZombie",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastStakeBlock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestConfirmed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestNodeCreated",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "staker",
+        "type": "address"
+      }
+    ],
+    "name": "latestStakedNode",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakerCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawableFunds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "zombieNum",
+        "type": "uint256"
+      }
+    ],
+    "name": "zombieAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "zombieCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "zombieNum",
+        "type": "uint256"
+      }
+    ],
+    "name": "zombieLatestStakedNode",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/arb-bridge-eth/package.json
+++ b/packages/arb-bridge-eth/package.json
@@ -3,13 +3,19 @@
   "version": "0.0.1",
   "license": "Apache-2.0",
   "scripts": {
-    "codegen": "yarn prepare:mainnet && graph codegen",
-    "build": "yarn prepare:mainnet && graph build",
+    "codegen": "yarn prepare:codegen && yarn prepare:mainnet && graph codegen",
+    "build": "yarn prepare:build && yarn prepare:mainnet && graph build",
     "postinstall": "yarn codegen",
-    "prepare:mainnet": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/mainnet.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
-    "prepare:rinkeby": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/rinkeby.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
+
+    "prepare:codegen": "yarn workspace subgraph-common mustache $(pwd)/src/interface/codegen.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.preprocessed.yaml",
+    "prepare:build": "yarn workspace subgraph-common mustache $(pwd)/src/interface/build.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.preprocessed.yaml",
+    
+    "prepare:mainnet": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/mainnet.json $(pwd)/subgraph.preprocessed.yaml | tail -n +2 > subgraph.yaml",
+    "prepare:rinkeby": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/rinkeby.json $(pwd)/subgraph.preprocessed.yaml | tail -n +2 > subgraph.yaml",
+    
     "deploy:mainnet": "yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-bridge-eth",
     "deploy:rinkeby": "yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-bridge-eth-rinkeby",
+
     "test": "rm -rf tests/.bin && yarn codegen && yarn build && graph test"
   },
   "dependencies": {

--- a/packages/arb-bridge-eth/package.json
+++ b/packages/arb-bridge-eth/package.json
@@ -13,8 +13,8 @@
     "prepare:mainnet": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/mainnet.json $(pwd)/subgraph.preprocessed.yaml | tail -n +2 > subgraph.yaml",
     "prepare:rinkeby": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/rinkeby.json $(pwd)/subgraph.preprocessed.yaml | tail -n +2 > subgraph.yaml",
     
-    "deploy:mainnet": "yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-bridge-eth",
-    "deploy:rinkeby": "yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-bridge-eth-rinkeby",
+    "deploy:mainnet": "yarn build && yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-bridge-eth",
+    "deploy:rinkeby": "yarn build && yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-bridge-eth-rinkeby",
 
     "test": "rm -rf tests/.bin && yarn codegen && yarn build && graph test"
   },

--- a/packages/arb-bridge-eth/schema.graphql
+++ b/packages/arb-bridge-eth/schema.graphql
@@ -44,3 +44,9 @@ type Retryable @entity {
   "calldata used in L2 call"
   l2Calldata: Bytes!
 }
+
+type Node @entity {
+  id: ID!
+  parentHash: Bytes!
+  blockCreatedAt: BigInt!
+}

--- a/packages/arb-bridge-eth/schema.graphql
+++ b/packages/arb-bridge-eth/schema.graphql
@@ -46,7 +46,14 @@ type Retryable @entity {
 }
 
 type Node @entity {
+  "node number in hex"
   id: ID!
+  "hash of information contained in this node"
+  nodeHash: Bytes!
+  "hash of parent node"
   parentHash: Bytes!
+  "block the node was created"
   blockCreatedAt: BigInt!
+  "count of inbox at time of assertion"
+  inboxMaxCount: BigInt!
 }

--- a/packages/arb-bridge-eth/schema.graphql
+++ b/packages/arb-bridge-eth/schema.graphql
@@ -45,6 +45,12 @@ type Retryable @entity {
   l2Calldata: Bytes!
 }
 
+enum NodeStatus {
+  Pending
+  Confirmed
+  Rejected
+}
+
 type Node @entity {
   "node number in hex"
   id: ID!
@@ -56,4 +62,6 @@ type Node @entity {
   blockCreatedAt: BigInt!
   "count of inbox at time of assertion"
   inboxMaxCount: BigInt!
+  "confirmation status of node in the rollup"
+  status: NodeStatus!
 }

--- a/packages/arb-bridge-eth/schema.graphql
+++ b/packages/arb-bridge-eth/schema.graphql
@@ -54,14 +54,25 @@ enum NodeStatus {
 type Node @entity {
   "node number in hex"
   id: ID!
+  
   "hash of information contained in this node"
   nodeHash: Bytes!
+  
   "hash of parent node"
   parentHash: Bytes!
+  
   "block the node was created"
   blockCreatedAt: BigInt!
+  
   "count of inbox at time of assertion"
   inboxMaxCount: BigInt!
+
+  "timestamp the node was created"
+  timestampCreated: BigInt!
+
+  "A node is created as pending, this is the timestamp in which it was either confirmed or rejected"
+  timestampStatusUpdate: BigInt
+  
   "confirmation status of node in the rollup"
   status: NodeStatus!
 }

--- a/packages/arb-bridge-eth/src/interface/IRollupCore.ts
+++ b/packages/arb-bridge-eth/src/interface/IRollupCore.ts
@@ -30,6 +30,19 @@ export class IRollupCoreNodeCreated__Params {
   get parentNodeHash(): Bytes {
     return this._event.parameters[1].value.toBytes();
   }
+
+  get nodeHash(): Bytes {
+    return this._event.parameters[2].value.toBytes();
+  }
+
+  get executionHash(): Bytes {
+    return this._event.parameters[3].value.toBytes();
+  }
+
+  get inboxMaxCount(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
   // TODO: add in other parameters
 }
 

--- a/packages/arb-bridge-eth/src/interface/IRollupCore.ts
+++ b/packages/arb-bridge-eth/src/interface/IRollupCore.ts
@@ -1,0 +1,41 @@
+// This was created manually because of https://github.com/graphprotocol/graph-cli/issues/342
+
+import {
+  ethereum,
+  JSONValue,
+  TypedMap,
+  Entity,
+  Bytes,
+  Address,
+  BigInt
+} from "@graphprotocol/graph-ts";
+
+export class IRollupCoreNodeCreated extends ethereum.Event {
+  get params(): IRollupCoreNodeCreated__Params {
+    return new IRollupCoreNodeCreated__Params(this);
+  }
+}
+
+export class IRollupCoreNodeCreated__Params {
+  _event: IRollupCoreNodeCreated;
+
+  constructor(event: IRollupCoreNodeCreated) {
+    this._event = event;
+  }
+
+  get nodeNum(): BigInt {
+    return this._event.parameters[0].value.toBigInt();
+  }
+
+  get parentNodeHash(): Bytes {
+    return this._event.parameters[1].value.toBytes();
+  }
+  // TODO: add in other parameters
+}
+
+export class IRollupCore extends ethereum.SmartContract {
+  static bind(address: Address): IRollupCore {
+    return new IRollupCore("IRollupCore", address);
+  }
+  // TODO: add in read-only methods
+}

--- a/packages/arb-bridge-eth/src/interface/IRollupCore.ts
+++ b/packages/arb-bridge-eth/src/interface/IRollupCore.ts
@@ -10,6 +10,53 @@ import {
   BigInt
 } from "@graphprotocol/graph-ts";
 
+export class IRollupCoreNodeRejected extends ethereum.Event {
+  get params(): IRollupCoreNodeRejected__Params {
+    return new IRollupCoreNodeRejected__Params(this);
+  }
+}
+
+export class IRollupCoreNodeRejected__Params {
+  _event: IRollupCoreNodeRejected;
+
+  constructor(event: IRollupCoreNodeRejected) {
+    this._event = event;
+  }
+
+  get nodeNum(): BigInt {
+    return this._event.parameters[0].value.toBigInt();
+  }
+}
+
+
+export class IRollupCoreNodeConfirmed extends ethereum.Event {
+  get params(): IRollupCoreNodeConfirmed__Params {
+    return new IRollupCoreNodeConfirmed__Params(this);
+  }
+}
+export class IRollupCoreNodeConfirmed__Params {
+  _event: IRollupCoreNodeConfirmed;
+
+  constructor(event: IRollupCoreNodeConfirmed) {
+    this._event = event;
+  }
+
+  get nodeNum(): BigInt {
+    return this._event.parameters[0].value.toBigInt();
+  }
+
+  get afterSendAcc(): Bytes {
+    return this._event.parameters[1].value.toBytes();
+  }
+
+  get afterSendCount(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  // TODO: add in other parameters
+}
+
+
 export class IRollupCoreNodeCreated extends ethereum.Event {
   get params(): IRollupCoreNodeCreated__Params {
     return new IRollupCoreNodeCreated__Params(this);

--- a/packages/arb-bridge-eth/src/interface/build.json
+++ b/packages/arb-bridge-eth/src/interface/build.json
@@ -1,0 +1,13 @@
+{
+    "rollupPreprocessor": "  - kind: ethereum/contract\n    name: IRollupCore\n    network: {{ l1Network }}\n    source:\n      address: '{{ rollupAddress }}'\n      abi: IRollupCore\n      startBlock: {{ rollupDeploymentBlock }}\n    mapping:\n      kind: ethereum/events\n      apiVersion: 0.0.5\n      language: wasm/assemblyscript\n      entities:\n        - Node\n      abis:\n        - name: IRollupCore\n          file: ./abis/IRollupCore.json\n      eventHandlers:\n        - event: NodeCreated(indexed uint256,indexed bytes32,bytes32,bytes32,uint256,uint256,bytes32,bytes32[3][2],uint256[4][2])\n          handler: handleNodeCreated\n      file: ./src/mapping.ts",
+      
+    "l1Network": "{{ l1Network }}",
+    "outboxDeploymentBlock": "{{ outboxDeploymentBlock }}",
+    "outboxAddress": "{{ outboxAddress }}",
+    "inboxDeploymentBlock": "{{ inboxDeploymentBlock }}",
+    "inboxAddress": "{{ inboxAddress }}",
+    "bridgeDeploymentBlock": "{{ bridgeDeploymentBlock }}",
+    "bridgeAddress": "{{ bridgeAddress }}",
+    "rollupAddress": "{{ rollupAddress }}",
+    "rollupDeploymentBlock": "{{ rollupDeploymentBlock }}"
+}

--- a/packages/arb-bridge-eth/src/interface/build.json
+++ b/packages/arb-bridge-eth/src/interface/build.json
@@ -1,6 +1,6 @@
 {
-    "rollupPreprocessor": "  - kind: ethereum/contract\n    name: IRollupCore\n    network: {{ l1Network }}\n    source:\n      address: '{{ rollupAddress }}'\n      abi: IRollupCore\n      startBlock: {{ rollupDeploymentBlock }}\n    mapping:\n      kind: ethereum/events\n      apiVersion: 0.0.5\n      language: wasm/assemblyscript\n      entities:\n        - Node\n      abis:\n        - name: IRollupCore\n          file: ./abis/IRollupCore.json\n      eventHandlers:\n        - event: NodeCreated(indexed uint256,indexed bytes32,bytes32,bytes32,uint256,uint256,bytes32,bytes32[3][2],uint256[4][2])\n          handler: handleNodeCreated\n      file: ./src/mapping.ts",
-      
+    "rollupPreprocessor": "  - kind: ethereum/contract\n    name: IRollupCore\n    network: {{ l1Network }}\n    source:\n      address: '{{ rollupAddress }}'\n      abi: IRollupCore\n      startBlock: {{ rollupDeploymentBlock }}\n    mapping:\n      kind: ethereum/events\n      apiVersion: 0.0.5\n      language: wasm/assemblyscript\n      entities:\n        - Node\n      abis:\n        - name: IRollupCore\n          file: ./abis/IRollupCore.json\n      eventHandlers:\n        - event: NodeCreated(indexed uint256,indexed bytes32,bytes32,bytes32,uint256,uint256,bytes32,bytes32[3][2],uint256[4][2])\n          handler: handleNodeCreated\n        - event: NodeConfirmed(indexed uint256,bytes32,uint256,bytes32,uint256)\n          handler: handleNodeConfirmed\n        - event: NodeRejected(indexed uint256)\n          handler: handleNodeRejected\n      file: ./src/mapping.ts",
+
     "l1Network": "{{ l1Network }}",
     "outboxDeploymentBlock": "{{ outboxDeploymentBlock }}",
     "outboxAddress": "{{ outboxAddress }}",

--- a/packages/arb-bridge-eth/src/interface/codegen.json
+++ b/packages/arb-bridge-eth/src/interface/codegen.json
@@ -1,0 +1,13 @@
+{
+    "rollupPreprocessor": "",
+
+    "l1Network": "{{ l1Network }}",
+    "outboxDeploymentBlock": "{{ outboxDeploymentBlock }}",
+    "outboxAddress": "{{ outboxAddress }}",
+    "inboxDeploymentBlock": "{{ inboxDeploymentBlock }}",
+    "inboxAddress": "{{ inboxAddress }}",
+    "bridgeDeploymentBlock": "{{ bridgeDeploymentBlock }}",
+    "bridgeAddress": "{{ bridgeAddress }}",
+    "rollupAddress": "{{ rollupAddress }}",
+    "rollupDeploymentBlock": "{{ rollupDeploymentBlock }}"
+}

--- a/packages/arb-bridge-eth/src/mapping.ts
+++ b/packages/arb-bridge-eth/src/mapping.ts
@@ -196,6 +196,8 @@ export function handleMessageDelivered(event: MessageDeliveredEvent): void {
 export function handleNodeCreated(event: NodeCreatedEvent): void {
   const id = bigIntToId(event.params.nodeNum);
   let entity = new NodeEntity(id);
+  entity.nodeHash = event.params.nodeHash;
+  entity.inboxMaxCount = event.params.inboxMaxCount
   entity.parentHash = event.params.parentNodeHash;
   entity.blockCreatedAt = event.block.number;
   entity.save();

--- a/packages/arb-bridge-eth/src/mapping.ts
+++ b/packages/arb-bridge-eth/src/mapping.ts
@@ -204,6 +204,8 @@ export function handleNodeCreated(event: NodeCreatedEvent): void {
   entity.inboxMaxCount = event.params.inboxMaxCount
   entity.parentHash = event.params.parentNodeHash;
   entity.blockCreatedAt = event.block.number;
+  entity.timestampCreated = event.block.timestamp;
+  entity.timestampStatusUpdate = null;
   entity.status = "Pending"
   entity.save();
 }
@@ -218,6 +220,7 @@ export function handleNodeConfirmed(event: NodeConfirmedEvent): void {
     log.critical("Should not confirm non-existent node", [])
     throw new Error("no node to confirm")
   }
+  entity.timestampStatusUpdate = event.block.timestamp
   entity.status = "Confirmed"
   entity.save()
 }
@@ -232,6 +235,7 @@ export function handleNodeRejected(event: NodeRejectedEvent): void {
     log.critical("Should not reject non-existent node", [])
     throw new Error("no node to reject")
   }
+  entity.timestampStatusUpdate = event.block.timestamp
   entity.status = "Rejected"
   entity.save()
 }

--- a/packages/arb-bridge-eth/src/mapping.ts
+++ b/packages/arb-bridge-eth/src/mapping.ts
@@ -4,11 +4,13 @@ import {
 } from "../generated/Outbox/Outbox";
 import { InboxMessageDelivered as InboxMessageDeliveredEvent } from "../generated/Inbox/Inbox";
 import { MessageDelivered as MessageDeliveredEvent } from "../generated/Bridge/Bridge";
+import { IRollupCoreNodeCreated as NodeCreatedEvent } from "./interface/IRollupCore";
 import {
   OutboxEntry,
   OutboxOutput,
   Retryable,
   RawMessage,
+  Node as NodeEntity,
 } from "../generated/schema";
 import {
   Bytes,
@@ -188,5 +190,12 @@ export function handleMessageDelivered(event: MessageDeliveredEvent): void {
   const id = bigIntToId(event.params.messageIndex);
   let entity = new RawMessage(id);
   entity.kind = event.params.kind == 9 ? "Retryable" : "NotSupported";
+  entity.save();
+}
+
+export function handleNodeCreated(event: NodeCreatedEvent): void {
+  const id = bigIntToId(event.params.nodeNum);
+  let entity = new NodeEntity(id);
+  entity.parentHash = event.params.parentNodeHash;
   entity.save();
 }

--- a/packages/arb-bridge-eth/src/mapping.ts
+++ b/packages/arb-bridge-eth/src/mapping.ts
@@ -197,5 +197,6 @@ export function handleNodeCreated(event: NodeCreatedEvent): void {
   const id = bigIntToId(event.params.nodeNum);
   let entity = new NodeEntity(id);
   entity.parentHash = event.params.parentNodeHash;
+  entity.blockCreatedAt = event.block.number;
   entity.save();
 }

--- a/packages/arb-bridge-eth/subgraph.template.yaml
+++ b/packages/arb-bridge-eth/subgraph.template.yaml
@@ -66,3 +66,4 @@ dataSources:
         - event: MessageDelivered(indexed uint256,indexed bytes32,address,uint8,address,bytes32)
           handler: handleMessageDelivered
       file: ./src/mapping.ts
+{{{ rollupPreprocessor }}}

--- a/packages/arbitrum-precompiles/package.json
+++ b/packages/arbitrum-precompiles/package.json
@@ -10,8 +10,8 @@
     "prepare:mainnet": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/mainnet.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
     "prepare:rinkeby": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/rinkeby.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
 
-    "deploy:mainnet": "yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-builtins",
-    "deploy:rinkeby": "yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-builtins-rinkeby"
+    "deploy:mainnet": "yarn build && yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-builtins",
+    "deploy:rinkeby": "yarn build && yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/arb-builtins-rinkeby"
   },
   "dependencies": {
     "subgraph-common": "0.0.1",

--- a/packages/layer1-token-gateway/package.json
+++ b/packages/layer1-token-gateway/package.json
@@ -10,8 +10,8 @@
     "prepare:mainnet": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/mainnet.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
     "prepare:rinkeby": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/rinkeby.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
 
-    "deploy:mainnet": "yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/layer1-token-gateway",
-    "deploy:rinkeby": "yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/layer1-token-gateway-rinkeby"
+    "deploy:mainnet": "yarn build && yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/layer1-token-gateway",
+    "deploy:rinkeby": "yarn build && yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/layer1-token-gateway-rinkeby"
   },
   "dependencies": {
     "subgraph-common": "0.0.1",

--- a/packages/layer2-token-gateway/package.json
+++ b/packages/layer2-token-gateway/package.json
@@ -10,8 +10,8 @@
     "prepare:mainnet": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/mainnet.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
     "prepare:rinkeby": "yarn workspace subgraph-common mustache $(pwd)/../subgraph-common/config/rinkeby.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
 
-    "deploy:mainnet": "yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/layer2-token-gateway",
-    "deploy:rinkeby": "yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/layer2-token-gateway-rinkeby",
+    "deploy:mainnet": "yarn build && yarn prepare:mainnet && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/layer2-token-gateway",
+    "deploy:rinkeby": "yarn build && yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ fredlacs/layer2-token-gateway-rinkeby",
     
     "test": "rm -rf tests/.bin && yarn codegen && yarn build && graph test"
   },

--- a/packages/subgraph-common/config/mainnet.json
+++ b/packages/subgraph-common/config/mainnet.json
@@ -12,5 +12,7 @@
     "l2StandardGateway": "0x09e9222E96E7B4AE2a407B98d48e330053351EEe",
     "l2StandardGatewayDeployBlock": 2107,
     "l1GatewayRouter": "0x72Ce9c846789fdB6fC1f34aC4AD25Dd9ef7031ef",
-    "l1GatewayRouterDeployBlock": 12640865
+    "l1GatewayRouterDeployBlock": 12640865,
+    "rollupAddress": "0xC12BA48c781F6e392B49Db2E25Cd0c28cD77531A",
+    "rollupDeploymentBlock": 12525700
 }

--- a/packages/subgraph-common/config/rinkeby.json
+++ b/packages/subgraph-common/config/rinkeby.json
@@ -12,5 +12,7 @@
     "l2StandardGateway": "0x195C107F3F75c4C93Eba7d9a1312F19305d6375f",
     "l2StandardGatewayDeployBlock": 122,
     "l1GatewayRouter": "0x70C143928eCfFaf9F5b406f7f4fC28Dc43d68380",
-    "l1GatewayRouterDeployBlock": 16210
+    "l1GatewayRouterDeployBlock": 16210,
+    "rollupAddress": "0xFe2c86CF40F89Fe2F726cFBBACEBae631300b50c",
+    "rollupDeploymentBlock": 8700589
 }


### PR DESCRIPTION
The graph-cli can't handle codegen with multi dimensional arrays as described in https://github.com/graphprotocol/graph-cli/issues/342

To get around this we don't include the Rollup dataSources when doing codegen, and instead use `packages/arb-bridge-eth/src/interface/IRollupCore.ts` for its types. When building the subgraph we then include the Rollup datasource declaration.

The rollup data source is declared in`rollupPreprocessor` block in `packages/arb-bridge-eth/src/interface/build.json`
This is annoying to maintain but is a stopgap so we can support this feature and still easily build the project while multi-dimensional array support isn't added.

The "preprocessor" adds the rollup info conditionally based on codegen vs build. This is then pipelined to the regular moustache templating pipeline. The intermediate step just reflects back the templated variable (ie `{{ l1Address }}` gets subbed for `{{ l1Address }}`)