### PR TITLE
chore: add blockNumber to l1GatewaySets

### DIFF
--- a/packages/layer1-token-gateway/schema.graphql
+++ b/packages/layer1-token-gateway/schema.graphql
@@ -7,6 +7,7 @@ type GatewaySet @entity {
   id: ID!
   l1Token: Bytes! # address
   gateway: Bytes! # address
+  blockNumber: Int! #uint32
 }
 
 type TransferRouted @entity {

--- a/packages/layer1-token-gateway/src/mapping.ts
+++ b/packages/layer1-token-gateway/src/mapping.ts
@@ -29,6 +29,7 @@ export function handleGatewaySet(event: GatewaySetEvent): void {
   )
   entity.l1Token = event.params.l1Token
   entity.gateway = event.params.gateway
+  entity.blockNumber = event.block
   entity.save()
 }
 


### PR DESCRIPTION
Add blockNumber to gatewaySet so we can order the results by their emit sequence.