### PR TITLE
Track retryables on L2

### DIFF
--- a/packages/arbitrum-retryables/abis/ArbRetryableTx.json
+++ b/packages/arbitrum-retryables/abis/ArbRetryableTx.json
@@ -1,0 +1,306 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "ArbRetryableTx",
+  "sourceName": "src/precompiles/ArbRetryableTx.sol",
+  "abi": [
+    {
+      "inputs": [],
+      "name": "NoTicketWithID",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotCallable",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "Canceled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newTimeout",
+          "type": "uint256"
+        }
+      ],
+      "name": "LifetimeExtended",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "retryTxHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint64",
+          "name": "sequenceNum",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "donatedGas",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "gasDonor",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "maxRefund",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "submissionFeeRefund",
+          "type": "uint256"
+        }
+      ],
+      "name": "RedeemScheduled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "userTxHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "Redeemed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "TicketCreated",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "cancel",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getBeneficiary",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getCurrentRedeemer",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getLifetime",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getTimeout",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "keepalive",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "ticketId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "redeem",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "requestId",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "l1BaseFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deposit",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "callvalue",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "gasFeeCap",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint64",
+          "name": "gasLimit",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxSubmissionFee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "feeRefundAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "beneficiary",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "retryTo",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "retryData",
+          "type": "bytes"
+        }
+      ],
+      "name": "submitRetryable",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/packages/arbitrum-retryables/package.json
+++ b/packages/arbitrum-retryables/package.json
@@ -6,7 +6,15 @@
     "codegen": "graph codegen",
     "build": "graph build",
     "postinstall": "yarn codegen",
-    "deploy:arb": "yarn build && graph deploy --node https://api.thegraph.com/deploy/ gvladika/arbitrum-retryables"
+
+    "prepare:arb": "yarn workspace @arbitrum/subgraph-common mustache $(pwd)/../subgraph-common/config/nitro-mainnet.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
+    "prepare:nova": "yarn workspace @arbitrum/subgraph-common mustache $(pwd)/../subgraph-common/config/nova.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
+    "prepare:goerli": "yarn workspace @arbitrum/subgraph-common mustache $(pwd)/../subgraph-common/config/goerli.json $(pwd)/subgraph.template.yaml | tail -n +2 > subgraph.yaml",
+
+    "deploy:arb": "yarn build && yarn prepare:arb && graph deploy --node https://api.thegraph.com/deploy/ gvladika/arbitrum-retryables",
+    "deploy:nova": "yarn build && yarn prepare:nova && graph deploy --node https://api.thegraph.com/deploy/ gvladika/arbitrum-retryables-nova",
+    "deploy:goerli": "yarn build && yarn prepare:goerli && graph deploy --node https://api.thegraph.com/deploy/ gvladika/arbitrum-retryables-goerli"
+
   },
   "dependencies": {
     "@arbitrum/subgraph-common": "0.0.1",

--- a/packages/arbitrum-retryables/package.json
+++ b/packages/arbitrum-retryables/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "arbitrum-retryables",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "scripts": {
+    "codegen": "graph codegen",
+    "build": "graph build",
+    "postinstall": "yarn codegen",
+    "deploy:arb": "yarn build && graph deploy --node https://api.thegraph.com/deploy/ gvladika/arbitrum-retryables"
+  },
+  "dependencies": {
+    "@arbitrum/subgraph-common": "0.0.1",
+    "@graphprotocol/graph-cli": "0.30.3",
+    "@graphprotocol/graph-ts": "0.27.0"
+  }
+}

--- a/packages/arbitrum-retryables/schema.graphql
+++ b/packages/arbitrum-retryables/schema.graphql
@@ -27,12 +27,25 @@ type Retryable @entity {
   "true if 1st reedem was successful"
   isAutoRedeemed: Boolean
 
-  "retryable execution params"
+  "retryable execution params from event"
   sequenceNum: BigInt
   donatedGas: BigInt
   gasDonor: Bytes #Address
   maxRefund: BigInt
   submissionFeeRefund: BigInt
+
+  "retryable submission params from tx input"
+  requestId: Bytes
+  l1BaseFee: BigInt
+  deposit: BigInt
+  callvalue: BigInt
+  gasFeeCap: BigInt
+  gasLimit: BigInt
+  maxSubmissionFee: BigInt
+  feeRefundAddress: String
+  beneficiary: String
+  retryTo: String
+  retryData: Bytes
 }
 
 type TotalRetryableStats @entity {

--- a/packages/arbitrum-retryables/schema.graphql
+++ b/packages/arbitrum-retryables/schema.graphql
@@ -1,0 +1,51 @@
+enum RetryableState {
+  Created
+  Canceled
+  Redeemed
+  RedeemFailed
+}
+
+type Retryable @entity {
+  "ticket id of retryable"
+  id: ID!
+
+  "ticket's status"
+  status: RetryableState!
+
+  "tx that redeemed the current retryable. this could have been an autoredeem"
+  retryTxHash: Bytes # bytes32
+
+  "this value is the creation timestamp plus the lifetime, which can be extended"
+  timeoutTimestamp: BigInt! # uint256
+
+  "timestamp at which ticket was created"
+  createdAtTimestamp: BigInt! # uint256
+
+  "block number at which ticket was created"
+  createdAtBlockNumber: BigInt! # uint256
+
+  "tx at which ticket was created"
+  createdAtTxHash: Bytes! # uint256
+
+  "timestamp at which ticket was successfully redeemed"
+  redeemedAtTimestamp: BigInt # uint256
+
+  "true if 1st reedem was successful"
+  isAutoRedeemed: Boolean
+
+  "retryable execution params"
+  sequenceNum: BigInt
+  donatedGas: BigInt
+  gasDonor: Bytes #Address
+  maxRefund: BigInt
+  submissionFeeRefund: BigInt
+}
+
+type TotalRetryableStats @entity {
+  id: ID!
+
+  totalCreated: BigInt!
+  autoRedeemed: BigInt!
+  successfullyRedeemed: BigInt!
+  failedToRedeem: BigInt!
+}

--- a/packages/arbitrum-retryables/schema.graphql
+++ b/packages/arbitrum-retryables/schema.graphql
@@ -14,22 +14,16 @@ type Retryable @entity {
 
   "tx that redeemed the current retryable. this could have been an autoredeem"
   retryTxHash: Bytes # bytes32
-
   "this value is the creation timestamp plus the lifetime, which can be extended"
   timeoutTimestamp: BigInt! # uint256
-
   "timestamp at which ticket was created"
   createdAtTimestamp: BigInt! # uint256
-
   "block number at which ticket was created"
   createdAtBlockNumber: BigInt! # uint256
-
   "tx at which ticket was created"
   createdAtTxHash: Bytes! # uint256
-
   "timestamp at which ticket was successfully redeemed"
   redeemedAtTimestamp: BigInt # uint256
-
   "true if 1st reedem was successful"
   isAutoRedeemed: Boolean
 
@@ -48,4 +42,5 @@ type TotalRetryableStats @entity {
   autoRedeemed: BigInt!
   successfullyRedeemed: BigInt!
   failedToRedeem: BigInt!
+  canceled: BigInt!
 }

--- a/packages/arbitrum-retryables/src/mapping.ts
+++ b/packages/arbitrum-retryables/src/mapping.ts
@@ -1,0 +1,95 @@
+import { Retryable } from "../generated/schema";
+import {
+  Canceled,
+  LifetimeExtended,
+  RedeemScheduled,
+  TicketCreated,
+  ArbRetryableTx as ArbRetryableTxContract,
+} from "../generated/ArbRetryableTx/ArbRetryableTx";
+import { Address, Bytes, log } from "@graphprotocol/graph-ts";
+import { RETRYABLE_LIFETIME_SECONDS } from "@arbitrum/subgraph-common/src/helpers";
+
+/**
+ * Create retryable entity when ticket is first created
+ * @param event
+ */
+export function handleTicketCreated(event: TicketCreated): void {
+  let ticketId = event.params.ticketId;
+  let entity = new Retryable(ticketId.toHexString());
+  entity.status = "Created";
+  entity.timeoutTimestamp = event.block.timestamp.plus(RETRYABLE_LIFETIME_SECONDS);
+  entity.createdAtTimestamp = event.block.timestamp;
+  entity.createdAtBlockNumber = event.block.number;
+  entity.createdAtTxHash = event.transaction.hash;
+  entity.save();
+}
+
+/**
+ * Update retryable's status to canceled
+ * @param event
+ */
+export function handleCanceled(event: Canceled): void {
+  let ticketId = event.params.ticketId;
+  let entity = Retryable.load(ticketId.toHexString());
+  if (!entity) {
+    log.critical("Missed a retryable ticket somewhere!", []);
+    throw new Error("No retryable ticket");
+  }
+  entity.status = "Canceled";
+  entity.save();
+}
+
+/**
+ * Extend retryable's timeout
+ * @param event
+ */
+export function handleLifetimeExtended(event: LifetimeExtended): void {
+  let ticketId = event.params.ticketId;
+  let entity = Retryable.load(ticketId.toHexString());
+  if (!entity) {
+    log.critical("Missed a retryable ticket somewhere!", []);
+    throw new Error("No retryable ticket");
+  }
+  entity.timeoutTimestamp = entity.timeoutTimestamp.plus(event.params.newTimeout);
+  entity.save();
+}
+
+/**
+ * Deduce if redeem was successful by doing contract call - if redeem was successful call will fail
+ * because ticket has been deleted from queue.
+ * @param event
+ */
+export function handleRedeemScheduled(event: RedeemScheduled): void {
+  let ticketId = event.params.ticketId;
+  let entity = Retryable.load(ticketId.toHexString());
+  if (!entity) {
+    log.critical("Missed a retryable ticket somewhere!", []);
+    throw new Error("No retryable ticket");
+  }
+  entity.retryTxHash = event.params.retryTxHash;
+
+  const redeemSuccessful = isRedeemSuccessful(ArbRetryableTxContract.bind(event.address), ticketId);
+  if (redeemSuccessful) {
+    if (entity.status == "Created") {
+      entity.isAutoRedeemed = true;
+    }
+    entity.status = "Redeemed";
+    entity.redeemedAtTimestamp = event.block.timestamp;
+  } else {
+    entity.isAutoRedeemed = false;
+    entity.status = "RedeemFailed";
+  }
+
+  entity.sequenceNum = event.params.sequenceNum;
+  entity.donatedGas = event.params.donatedGas;
+  entity.gasDonor = event.params.gasDonor;
+  entity.maxRefund = event.params.maxRefund;
+  entity.submissionFeeRefund = event.params.submissionFeeRefund;
+
+  entity.save();
+}
+
+function isRedeemSuccessful(contract: ArbRetryableTxContract, ticketId: Bytes): boolean {
+  const beneficiaryCall = contract.try_getBeneficiary(ticketId);
+  return beneficiaryCall.reverted;
+}

--- a/packages/arbitrum-retryables/subgraph.template.yaml
+++ b/packages/arbitrum-retryables/subgraph.template.yaml
@@ -1,0 +1,34 @@
+specVersion: 0.0.4
+description: Subgraph that indexes Arbitrum precompile contracts
+schema:
+  file: schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ArbRetryableTx
+    network: {{ l2Network }}
+    source:
+      address: "0x000000000000000000000000000000000000006E"
+      abi: ArbRetryableTx
+      startBlock: {{ nitroGenesisBlockNum }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - Canceled
+        - LifetimeExtended
+        - RedeemScheduled
+        - TicketCreated
+      abis:
+        - name: ArbRetryableTx
+          file: ./abis/ArbRetryableTx.json
+      eventHandlers:
+        - event: Canceled(indexed bytes32)
+          handler: handleCanceled
+        - event: LifetimeExtended(indexed bytes32,uint256)
+          handler: handleLifetimeExtended
+        - event: TicketCreated(indexed bytes32)
+          handler: handleTicketCreated
+        - event: RedeemScheduled(indexed bytes32,indexed bytes32,indexed uint64,uint64,address,uint256,uint256)
+          handler: handleRedeemScheduled
+      file: ./src/mapping.ts

--- a/packages/subgraph-common/config/goerli.json
+++ b/packages/subgraph-common/config/goerli.json
@@ -16,5 +16,6 @@
   "rollupAddress": "0x45e5caea8768f42b385a366d3551ad1e0cbfab17",
   "rollupDeploymentBlock": 7217526,
   "l1GatewayRouter": "0x4c7708168395aEa569453Fc36862D2ffcDaC588c",
-  "l1GatewayRouterDeployBlock": 7223070
+  "l1GatewayRouterDeployBlock": 7223070,
+  "nitroGenesisBlockNum": 0
 }

--- a/packages/subgraph-common/config/nitro-mainnet.json
+++ b/packages/subgraph-common/config/nitro-mainnet.json
@@ -12,5 +12,6 @@
   "rollupAddress": "0x5ef0d09d1e6204141b4d37530808ed19f60fba35",
   "rollupDeploymentBlock": 15411056,
   "l1GatewayRouter": "0x72Ce9c846789fdB6fC1f34aC4AD25Dd9ef7031ef",
-  "l1GatewayRouterDeployBlock": 12640865
+  "l1GatewayRouterDeployBlock": 12640865,
+  "nitroGenesisBlockNum": 22207817
 }


### PR DESCRIPTION
Add new subgraph for tracking Nitro retryables on L2 side. We subscribe to retryable precompile's  events and we also parse transaction input data to get ticket's params. 