### PR TITLE
Fix entity ID construction - use log index to make IDs unique

### DIFF
--- a/packages/arb-bridge-eth/src/bridge.ts
+++ b/packages/arb-bridge-eth/src/bridge.ts
@@ -117,7 +117,7 @@ export function handleInboxMessageDelivered(event: InboxMessageDeliveredEvent): 
 
 function handleNitroEthDeposit(event: InboxMessageDeliveredEvent, rawMessage: RawMessage): void {
   // we track deposits with EthDeposit entities
-  let depositId = event.transaction.hash.toHexString() + "-" + event.transaction.index.toString();
+  let depositId = event.transaction.hash.toHexString() + "-" + event.logIndex.toString();
   let entity = new Deposit(depositId);
   entity.type = "EthDeposit";
 
@@ -198,7 +198,7 @@ function handleClassicRetryable(
     if (retryable.dataLength == BigInt.zero()) {
       // we track deposits with EthDeposit entities
       let depositId =
-        event.transaction.hash.toHexString() + "-" + event.transaction.index.toString();
+        event.transaction.hash.toHexString() + "-" + event.logIndex.toString();
       let deposit = new Deposit(depositId);
       deposit.type = "EthDeposit";
 

--- a/packages/arb-bridge-eth/src/tokenBridge.ts
+++ b/packages/arb-bridge-eth/src/tokenBridge.ts
@@ -33,7 +33,7 @@ const ARB_ONE_BLOCK_OF_LAST_CLASSIC_TOKEN_DEPOSIT = 15446977;
  */
 export function handleDepositInitiated(event: DepositInitiated): void {
   let tokenDepositId =
-    event.transaction.hash.toHexString() + "-" + event.transaction.index.toString();
+    event.transaction.hash.toHexString() + "-" + event.logIndex.toString();
 
   let tokenDeposit = new Deposit(tokenDepositId);
   tokenDeposit.type = "TokenDeposit";

--- a/packages/arb-bridge-eth/tests/inbox/inbox.test.ts
+++ b/packages/arb-bridge-eth/tests/inbox/inbox.test.ts
@@ -182,7 +182,7 @@ test("Can properly decode Eth deposit message data", () => {
   // check EthDeposit entity is properly created
 
   let id =
-    newInboxEvent.transaction.hash.toHexString() + "-" + newInboxEvent.transaction.index.toString();
+    newInboxEvent.transaction.hash.toHexString() + "-" + newInboxEvent.logIndex.toString();
   assert.fieldEquals(ETH_DEPOSIT_ENTITY_TYPE, id, "id", id);
   assert.fieldEquals(
     ETH_DEPOSIT_ENTITY_TYPE,
@@ -216,7 +216,7 @@ test("Can properly decode Eth deposit message data", () => {
   id =
     eventAddrOneLeadingZero.transaction.hash.toHexString() +
     "-" +
-    eventAddrOneLeadingZero.transaction.index.toString();
+    eventAddrOneLeadingZero.logIndex.toString();
   assert.fieldEquals(ETH_DEPOSIT_ENTITY_TYPE, id, "id", id);
   assert.fieldEquals(
     ETH_DEPOSIT_ENTITY_TYPE,
@@ -250,7 +250,7 @@ test("Can properly decode Eth deposit message data", () => {
   id =
     eventAddrMultipleLeadingZero.transaction.hash.toHexString() +
     "-" +
-    eventAddrMultipleLeadingZero.transaction.index.toString();
+    eventAddrMultipleLeadingZero.logIndex.toString();
   assert.fieldEquals(ETH_DEPOSIT_ENTITY_TYPE, id, "id", id);
   assert.fieldEquals(
     ETH_DEPOSIT_ENTITY_TYPE,
@@ -284,7 +284,7 @@ test("Can properly decode Eth deposit message data", () => {
   id =
     eventAddrStartEndZeros.transaction.hash.toHexString() +
     "-" +
-    eventAddrStartEndZeros.transaction.index.toString();
+    eventAddrStartEndZeros.logIndex.toString();
   assert.fieldEquals(ETH_DEPOSIT_ENTITY_TYPE, id, "id", id);
   assert.fieldEquals(
     ETH_DEPOSIT_ENTITY_TYPE,

--- a/packages/layer2-token-gateway/src/mapping.ts
+++ b/packages/layer2-token-gateway/src/mapping.ts
@@ -103,7 +103,7 @@ export function handleWithdrawal(event: WithdrawalInitiatedEvent): void {
 
   /// additionally create Withdrawal entity which tracks both Eth and token withdrawals
   const withdrawal = new Withdrawal(
-    event.transaction.hash.toHexString() + "-" + event.transaction.index.toString()
+    event.transaction.hash.toHexString() + "-" + event.logIndex.toString()
   );
   withdrawal.type = "TokenWithdrawal";
   withdrawal.sender = event.params._from;
@@ -228,7 +228,7 @@ export function handleNitroL2ToL1Transaction(event: NitroL2ToL1TxEvent): void {
 
   /// additionally create Withdrawal entity which tracks both Eth and token withdrawals
   const withdrawal = new Withdrawal(
-    event.transaction.hash.toHexString() + "-" + event.transaction.index.toString()
+    event.transaction.hash.toHexString() + "-" + event.logIndex.toString()
   );
   withdrawal.type = "EthWithdrawal";
   withdrawal.sender = event.params.caller;
@@ -274,7 +274,7 @@ export function handleClassicL2ToL1Transaction(event: ClassicL2ToL1TransactionEv
 
   /// additionally create Withdrawal entity which tracks both Eth and token withdrawals
   const withdrawal = new Withdrawal(
-    event.transaction.hash.toHexString() + "-" + event.transaction.index.toString()
+    event.transaction.hash.toHexString() + "-" + event.logIndex.toString()
   );
   withdrawal.type = "EthWithdrawal";
   withdrawal.sender = event.params.caller;


### PR DESCRIPTION
This fixes edge case when there are multiple deposits/withdrawals/etc in the same TX. Instead of overwriting each other now they'll have unique IDs