### PR TITLE
fix(cctp): decode MessageSent without invalid bytes128 ABI type

### DIFF
--- a/packages/cctp/src/usdc-message-transmitter.ts
+++ b/packages/cctp/src/usdc-message-transmitter.ts
@@ -25,6 +25,11 @@ function leftPadBytes(data: Bytes, length: number): Bytes {
   return completeData;
 }
 
+function bigIntFromBigEndianBytes(data: Uint8Array): BigInt {
+  // BigInt.fromUnsignedBytes expects little-endian bytes
+  return BigInt.fromUnsignedBytes(Bytes.fromUint8Array(data.slice(0).reverse()));
+}
+
 function getIdFromMessage(sourceDomain: BigInt, noncePadded: Bytes): Bytes {
   return Bytes.fromHexString(
     `0${sourceDomain.toString()}${noncePadded.toHexString()}`
@@ -121,47 +126,28 @@ function handleMessageSent(
   event: MessageSentEvent,
   expectedDestinationDomain: ChainDomain
 ): void {
-  // message is encoded with encodePacked, we need to pad non-bytes parameter (uint32, uint64) to 32 bytes (= 256 bits)
-  const message = event.params.message;
-  const versionSlice = message.slice(0, 4);
-  const sourceDomainSlice = message.slice(4, 8);
-  const destinationDomainSlice = message.slice(8, 12);
-  const nonceSlice = message.subarray(12, 20);
-
-  const versionPadded = leftPadBytes(Bytes.fromUint8Array(versionSlice), 32);
-  const sourceDomainPadded = leftPadBytes(
-    Bytes.fromUint8Array(sourceDomainSlice),
-    32
-  );
-  const destinationDomainPadded = leftPadBytes(
-    Bytes.fromUint8Array(destinationDomainSlice),
-    32
-  );
-
-  const noncePadded = leftPadBytes(Bytes.fromUint8Array(nonceSlice), 32);
-  const messagePadded = versionPadded
-    .concat(sourceDomainPadded)
-    .concat(destinationDomainPadded)
-    .concat(noncePadded)
-    .concat(Bytes.fromUint8Array(message.slice(24)));
-
+  // message is encoded with encodePacked, fields sit at fixed byte offsets:
+  // version [0:4], sourceDomain [4:8], destinationDomain [8:12], nonce [12:20],
+  // sender [20:52], recipient [52:84], destinationCaller [84:116], messageBody [116:]
   // see https://developers.circle.com/stablecoin/docs/cctp-technical-reference#message
-  const decodedMessageData = ethereum.decode(
-    // (version, sourceDomain, destinationDomain, nonce, sender, recipient, destinationcaller, messageBody)
-    "(uint32,uint32,uint32,uint64,bytes32,bytes32,bytes32,bytes128)",
-    messagePadded
-  );
-
-  if (!decodedMessageData) {
-    log.error("decodedMessageData doesn't exist", []);
+  // Read with byte slices, not ethereum.decode: https://github.com/graphprotocol/graph-node/issues/6683
+  const message = event.params.message;
+  if (message.length < 248) {
+    log.error("[handleMessageSent]: message is too short ({} bytes)", [
+      message.length.toString(),
+    ]);
     return;
   }
 
-  const decodedMessageDataTuple = decodedMessageData.toTuple();
-  const destinationDomain = decodedMessageDataTuple[2].toBigInt();
-  const sourceDomain = decodedMessageDataTuple[1].toBigInt();
-  const nonce = decodedMessageDataTuple[3].toBigInt();
-  const messageBody = decodedMessageDataTuple[7].toBytes();
+  const sourceDomain = bigIntFromBigEndianBytes(message.slice(4, 8));
+  const destinationDomain = bigIntFromBigEndianBytes(message.slice(8, 12));
+  const nonce = bigIntFromBigEndianBytes(message.slice(12, 20));
+  const noncePadded = leftPadBytes(
+    Bytes.fromUint8Array(message.slice(12, 20)),
+    32
+  );
+  // skip the 4-byte messageBody version, keep the 4 32-byte words
+  const messageBody = Bytes.fromUint8Array(message.slice(120, 248));
 
   if (destinationDomain.notEqual(BigInt.fromI32(expectedDestinationDomain))) {
     log.warning(

--- a/packages/cctp/tests/usdc-message-transmitter.test.ts
+++ b/packages/cctp/tests/usdc-message-transmitter.test.ts
@@ -314,6 +314,34 @@ describe("Message events", () => {
       messageSentHandler("L2", ChainDomain.Arbitrum, ChainDomain.Mainnet);
     });
 
+    test(`MessageSent decoded from a real mainnet message (L1)`, () => {
+      // message emitted in Ethereum tx 0x77894001ee62c0b245e6e9c3b35fcdc79e917ce352b20a0b2ec49e8d916734c2
+      const event = createMessageSentEvent(
+        Bytes.fromHexString(
+          "0x0000000000000000000000030000000000075aff000000000000000000000000bd3fa81b58ba92a82136038b25adec7066af315500000000000000000000000019330d10d9cc8751218eaf51e8885d058642e08a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000002a306013ecef96c2fd06995f7f140a17a095da71000000000000000000000000000000000000000000000000000000174876e8000000000000000000000000002a306013ecef96c2fd06995f7f140a17a095da71"
+        )
+      );
+      handleMessageSentL1(event);
+      const id =
+        "0x00000000000000000000000000000000000000000000000000000000000000075aff";
+      assert.entityCount("MessageSent", 1);
+      assert.fieldEquals("MessageSent", id, "sourceDomain", "0");
+      assert.fieldEquals("MessageSent", id, "nonce", "482047"); // 0x75aff
+      assert.fieldEquals("MessageSent", id, "amount", "100000000000");
+      assert.fieldEquals(
+        "MessageSent",
+        id,
+        "sender",
+        "0x2a306013ecef96c2fd06995f7f140a17a095da71"
+      );
+      assert.fieldEquals(
+        "MessageSent",
+        id,
+        "recipient",
+        "0x2a306013ecef96c2fd06995f7f140a17a095da71"
+      );
+    });
+
     test(`Older MessageSent event with same (nonce, sourceDomain) is skipped (L1)`, () => {
       olderMessageSentIsSkipped(
         "L1",


### PR DESCRIPTION
graph-node >= 0.42 (alloy ABI decoder) rejects the invalid `bytes128` type used in `handleMessageSent`, so `ethereum.decode` returns null and MessageSent entities are silently skipped. Indexers on newer graph-node versions stop indexing them while the subgraph still reports healthy and synced (see graphprotocol/graph-node#6683).

This replaces the decode with byte slices at the fixed offsets of the CCTP message format. Entity IDs and fields are unchanged. Added a regression test using a real mainnet message.